### PR TITLE
updating rprocess, red kilonova

### DIFF
--- a/mosfit/models/rprocess/parameters.json
+++ b/mosfit/models/rprocess/parameters.json
@@ -13,11 +13,6 @@
         "min_value":-500.0,
         "max_value":500.0
     },
-    "temperature":{
-        "min_value":1.0e3,
-        "max_value":1.0e5,
-        "log":true
-    },
     "mejecta":{
         "min_value":1.0e-3,
         "max_value":1.0e-1,

--- a/mosfit/models/rprocess/rprocess.json
+++ b/mosfit/models/rprocess/rprocess.json
@@ -28,7 +28,7 @@
     },
     "kappa":{
         "kind":"parameter",
-        "value":200.0,
+        "value":10.0,
         "class":"parameter",
         "latex":"\\kappa\\,({\\rm cm}^{2}\\,{\\rm g}^{-1})"
     },

--- a/mosfit/modules/engines/rprocess.py
+++ b/mosfit/modules/engines/rprocess.py
@@ -11,7 +11,7 @@ class RProcess(Engine):
     """r-process decay engine
         input luminosity adapted from Metzger 2016: 2016arXiv161009381M
 
-        For 'red' kilonovae, use kappa ~ 200
+        For 'red' kilonovae, use kappa ~ 10
         For 'blue' kilonovae, use kappa ~1
 
     """


### PR DESCRIPTION
red kilonova was using a different diffusion mechanism in older version. Using kappa ~ 10 matches the red kilonova SED from Metzger 2016