### PR TITLE
BUG: in mossampler concerning single free parameter

### DIFF
--- a/mosfit/mossampler.py
+++ b/mosfit/mossampler.py
@@ -191,7 +191,7 @@ class MOSSampler(PTSampler):
 
         for i in range(iterations):
             thawed = np.array(sorted(np.random.choice(
-                self.dim, np.random.randint(1, self.dim), replace=False)))
+                self.dim, np.random.randint(1, self.dim+1), replace=False)))
             for j in [0, 1]:
                 jupdate = j
                 jsample = (j + 1) % 2

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@ else
     TRUNNER=python
 fi
 
-mpirun -np 2 $RUNNER -m mosfit -e SN2009do --test -i 1 -f 1 -p 0 -F covariance
+mpirun -np 2 --oversubscribe $RUNNER -m mosfit -e SN2009do --test -i 1 -f 1 -p 0 -F covariance
 $RUNNER -m mosfit -e SN2009do.json --test -i 1 --no-fracking -m magnetar -T 2 -F covariance
 $RUNNER -m mosfit -e SN2007bg --test -i 3 -m rprocess -D nester -F covariance
 $RUNNER -m mosfit -e mosfit/tests/LSQ12dlf.json --test -i 3 --no-fracking -m csm -F n 6.0 -W 120 -M 0.2 --offline


### PR DESCRIPTION
np.random.randint() is now selected on the range [1,self.dim] inclusive. 