### PR TITLE
change default band samples from 17 to 25

### DIFF
--- a/mosfit/main.py
+++ b/mosfit/main.py
@@ -177,7 +177,7 @@ def get_parser(only=None, printer=None):
         '--band-sampling-points',
         dest='band_sampling_points',
         type=int,
-        default=17,
+        default=25,
         help=prt.text('parser_band_sampling_points'))
 
     parser.add_argument(

--- a/mosfit/model.py
+++ b/mosfit/model.py
@@ -353,7 +353,7 @@ class Model(object):
                   band_systems=[],
                   band_instruments=[],
                   band_bandsets=[],
-                  band_sampling_points=17,
+                  band_sampling_points=25,
                   variance_for_each=[],
                   user_fixed_parameters=[],
                   user_released_parameters=[],

--- a/mosfit/modules/seds/sed.py
+++ b/mosfit/modules/seds/sed.py
@@ -22,7 +22,7 @@ class SED(Module):
     def __init__(self, **kwargs):
         """Initialize module."""
         super(SED, self).__init__(**kwargs)
-        self._N_PTS = 16 + 1
+        self._N_PTS = 24 + 1
         self._sample_wavelengths = []
 
     def receive_requests(self, **requests):


### PR DESCRIPTION
The number of samples used to interpolate the filters affects some results significantly, especially for i-band, which has a non-smooth profile. Changing the number of filter samples from 17 to 25 brings down the error on i-band from 0.06mag to 0.01mag, and has a very minimal effect on computation time.

This plot shows the absolute magnitude of the difference between a model with a given band samples, to one using 200 samples. 25 samples corresponds to ~ 0.01mag difference in i-band:
![image](https://user-images.githubusercontent.com/10391602/54955133-db67b500-4f22-11e9-81f7-4a4630a4cb5a.png)
