### PR TITLE
Making true beta a derived parameter of b (scaled beta)

### DIFF
--- a/mosfit/models/tde/tde.json
+++ b/mosfit/models/tde/tde.json
@@ -36,7 +36,8 @@
         "kind":"parameter",
         "value": 0.98,
         "class":"parameter",
-        "latex":"b\\ (\\rm scaled\\ \\beta)"
+        "latex":"b\\ (\\rm scaled\\ \\beta)",
+        "derived_keys":"beta"
     },
     "Tviscous":{
         "kind":"parameter",


### PR DESCRIPTION
The beta parameter in the TDE model is very useful. Sampling is done with a scaled version of beta, recovering true beta is non-trivial so making it a derived parameter to be written to the output files.