### PR TITLE
add luminosity and time outputs to the blackbody sed model for TDEs

### DIFF
--- a/mosfit/modules/seds/blackbody.py
+++ b/mosfit/modules/seds/blackbody.py
@@ -31,6 +31,7 @@ class Blackbody(SED):
         self._frequencies = kwargs['all_frequencies']
         self._radius_phot = kwargs[self.key('radiusphot')]
         self._temperature_phot = kwargs[self.key('temperaturephot')]
+        self._times = np.array(kwargs['rest_times'])
         xc = self.X_CONST  # noqa: F841
         fc = self.FLUX_CONST  # noqa: F841
         cc = self.C_CONST
@@ -78,4 +79,9 @@ class Blackbody(SED):
         seds = self.add_to_existing_seds(seds, **kwargs)
 
         # Units of `seds` is ergs / s / Angstrom.
-        return {'sample_wavelengths': self._sample_wavelengths, 'seds': seds}
+        return {
+            'sample_wavelengths': self._sample_wavelengths,
+            self.key('seds'): seds,
+            'luminosities_out': self._luminosities,
+            'times_out': self._times
+        }

--- a/mosfit/requirements.txt
+++ b/mosfit/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 astrocats>=0.3.33
 astropy>=5.0.1
 Cython>=3.0.0


### PR DESCRIPTION
@gmzsebastian and I noticed that the `blackbody.py` file used for the TDE model was not outputting the luminosity and time to the `extras.json` file properly. I fixed that issue here using similar code to in the `blackbody_supressed.py` code.

I also had modified the requirements file to get mosfit to install on my computer. I can roll that back though if necessary.  