### PR TITLE
fall back to a writable cache dir on read-only installs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,9 @@
 name: Build and push MOSFiT image
 
 # Builds the MOSFiT CPU runtime image. The image is pushed to Docker Hub ONLY
-# from master (and version tags); pushes to any other branch and pull requests just
-# build, so a broken image fails the check without publishing. From Docker Hub the
+# from master (and version tags) AND only where the DOCKERHUB_TOKEN secret is set,
+# so forks and other branches / pull requests just build (a broken image fails the
+# check without publishing, and a fork without the secret won't fail on login). From Docker Hub the
 # CVMFS unpacked sync (a separate PR against opensciencegrid/cvmfs-singularity-sync)
 # mirrors it to /cvmfs/singularity.opensciencegrid.org/<user>/mosfit:<tag>.
 #
@@ -29,9 +30,10 @@ jobs:
   build-push:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Publish only from master and version tags; every other ref builds only.
+    # Publish only from master/tags AND only where the Docker Hub secret is set, so
+    # forks (without the secret) build-only instead of failing the login step.
     env:
-      PUBLISH: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
+      PUBLISH: ${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && secrets.DOCKERHUB_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/mosfit/converter.py
+++ b/mosfit/converter.py
@@ -53,10 +53,19 @@ class Converter(object):
         self._cache_path = cache_path
         if self._cache_path:
             self._path = cache_path
-            if not os.path.isdir(os.path.join(self._path,'cache')):
-                os.makedirs(os.path.join(self._path,'cache'))
         else:
-            self._path = os.path.dirname(os.path.realpath(__file__))
+            # Default to the package dir, but fall back to a writable location when
+            # it is read-only (e.g. an installed/containerized MOSFiT).
+            pkg_dir = os.path.dirname(os.path.realpath(__file__))
+            override = os.environ.get('MOSFIT_CACHE_DIR')
+            if override:
+                self._path = override
+            elif os.access(pkg_dir, os.W_OK):
+                self._path = pkg_dir
+            else:
+                self._path = os.path.join(os.path.expanduser('~'), '.mosfit')
+        if not os.path.isdir(os.path.join(self._path, 'cache')):
+            os.makedirs(os.path.join(self._path, 'cache'))
         self._inflect = inflect.engine()
         self._printer = printer
         self._guess = guess


### PR DESCRIPTION
This PR falls back to a writable cache dir on read-only installs (issues with the container otherwise).