### PR TITLE
Support for newer numpy versions for MOSFiT

### DIFF
--- a/mosfit/modules/energetics/bns_ejecta.py
+++ b/mosfit/modules/energetics/bns_ejecta.py
@@ -1,6 +1,11 @@
 """Definitions for the `BNSEjecta` class."""
 
 import numpy as np
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
+
 from astrocats.catalog.source import SOURCE
 # import astropy.constants as c
 
@@ -200,8 +205,8 @@ class BNSEjecta(Energetic):
         atheta1 = 2*np.pi*np.sin(theta1)
         atheta2 = 2*np.pi*np.sin(theta2)
 
-        vejecta_blue = np.trapz(vtheta1*atheta1,x=theta1)/np.trapz(atheta1,x=theta1)
-        vejecta_red = np.trapz(vtheta2*atheta2,x=theta2)/np.trapz(atheta2,x=theta2)
+        vejecta_blue = trapezoid(vtheta1*atheta1,x=theta1)/trapezoid(atheta1,x=theta1)
+        vejecta_red = trapezoid(vtheta2*atheta2,x=theta2)/trapezoid(atheta2,x=theta2)
 
         vejecta_red *= ckm
         vejecta_blue *= ckm

--- a/mosfit/modules/energetics/bns_ejecta_generative.py
+++ b/mosfit/modules/energetics/bns_ejecta_generative.py
@@ -1,6 +1,11 @@
 """Definitions for the `BNSEjecta` class."""
 # import astropy.constants as c
 import numpy as np
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
+
 from astrocats.catalog.source import SOURCE
 
 from mosfit.constants import FOE, KM_CGS, M_SUN_CGS, C_CGS, G_CGS
@@ -132,8 +137,8 @@ class BNSEjecta(Energetic):
         atheta1 = 2*np.pi*np.sin(theta1)
         atheta2 = 2*np.pi*np.sin(theta2)
 
-        vejecta_blue = np.trapz(vtheta1*atheta1,x=theta1)/np.trapz(atheta1,x=theta1)
-        vejecta_red = np.trapz(vtheta2*atheta2,x=theta2)/np.trapz(atheta2,x=theta2)
+        vejecta_blue = trapezoid(vtheta1*atheta1,x=theta1)/trapezoid(atheta1,x=theta1)
+        vejecta_red = trapezoid(vtheta2*atheta2,x=theta2)/trapezoid(atheta2,x=theta2)
 
         mejecta_red = Mejdyn * f_red
         vejecta_red *= ckm

--- a/mosfit/modules/engines/bns_magnetar.py
+++ b/mosfit/modules/engines/bns_magnetar.py
@@ -2,6 +2,11 @@
 from math import isnan
 
 import numpy as np
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
+
 from scipy.integrate import cumulative_trapezoid
 from astrocats.catalog.source import SOURCE
 

--- a/mosfit/modules/observables/photometry.py
+++ b/mosfit/modules/observables/photometry.py
@@ -7,6 +7,11 @@ from collections import OrderedDict
 from copy import deepcopy
 
 import numpy as np
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
+
 from astropy import constants as c
 from astropy import units as u
 from astropy.io.votable import parse as voparse
@@ -374,30 +379,30 @@ class Photometry(Module):
                 self._band_energies[
                     i], self._band_areas[i] = xvals, yvals / xvals
                 self._band_wavelengths[i] = xscale / self._band_energies[i]
-                self._average_wavelengths[i] = np.trapz([
+                self._average_wavelengths[i] = trapezoid([
                     x * y
                     for x, y in zip(
                         self._band_areas[i], self._band_wavelengths[i])
-                ], self._band_wavelengths[i]) / np.trapz(
+                ], self._band_wavelengths[i]) / trapezoid(
                     self._band_areas[i], self._band_wavelengths[i])
             else:
                 self._band_wavelengths[
                     i], self._transmissions[i] = xvals, yvals
                 # scale by zero-point flux (Flbda = Fnu*c/lbda^2)
-                self._filter_integrals[i] = self.FLUX_STD * np.trapz(
+                self._filter_integrals[i] = self.FLUX_STD * trapezoid(
                     np.array(self._transmissions[i]) /
                     np.array(self._band_wavelengths[i]) ** 2,
                     self._band_wavelengths[i])
-                self._count_integrals[i] = self.FLUX_STD * np.trapz(
+                self._count_integrals[i] = self.FLUX_STD * trapezoid(
                     np.array(self._transmissions[i]) /
                     np.array(self._band_wavelengths[i]) ** 2 / (
                         H_C_ANG_CGS / self._band_wavelengths[i]),
                     self._band_wavelengths[i])
-                self._average_wavelengths[i] = np.trapz([
+                self._average_wavelengths[i] = trapezoid([
                     x * y
                     for x, y in zip(
                         self._transmissions[i], self._band_wavelengths[i])
-                ], self._band_wavelengths[i]) / np.trapz(
+                ], self._band_wavelengths[i]) / trapezoid(
                     self._transmissions[i], self._band_wavelengths[i])
 
                 if 'offset' in band:
@@ -530,7 +535,7 @@ class Photometry(Module):
                     yvals = np.interp(
                         wavs, self._band_wavelengths[bi],
                         self._transmissions[bi]) * kwargs['seds'][li] / zp1
-                    eff_fluxes[li] = np.trapz(
+                    eff_fluxes[li] = trapezoid(
                         yvals, wavs) / self._filter_integrals[bi]
                 elif self._observation_types[li] == 'countrate':
                     wavs = np.array(kwargs['sample_wavelengths'][bi])
@@ -538,7 +543,7 @@ class Photometry(Module):
                         wavs, self._band_wavelengths[bi],
                         self._band_areas[bi]) * kwargs['seds'][li] / zp1 / (
                             H_C_ANG_CGS / wavs) / ANG_CGS
-                    eff_fluxes[li] = np.trapz(yvals, wavs)
+                    eff_fluxes[li] = trapezoid(yvals, wavs)
                 else:
                     raise RuntimeError('Unknown observation kind.')
             else:

--- a/mosfit/modules/seds/blackbody_supressed.py
+++ b/mosfit/modules/seds/blackbody_supressed.py
@@ -3,6 +3,11 @@ from math import pi
 
 import numexpr as ne
 import numpy as np
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
+
 from astrocats.catalog.source import SOURCE
 from astropy import constants as c
 from astropy import units as u
@@ -152,7 +157,7 @@ class BlackbodyCutoff(SED):
         uniq_is = np.searchsorted(self._times, uniq_times, sorter=tsort)
 
         bb_wavelengths = np.linspace(100, 100000, self.N_TERMS)
-        norms = np.array([(R2 * self.STEF_CONST * T ** 4) / np.trapz(bbody_sup(bb_wavelengths,T,R2,self._cutoff_wavelength,self._alpha), bb_wavelengths) for T, R2 in zip(tp[uniq_is],rp2[uniq_is])])
+        norms = np.array([(R2 * self.STEF_CONST * T ** 4) / trapezoid(bbody_sup(bb_wavelengths,T,R2,self._cutoff_wavelength,self._alpha), bb_wavelengths) for T, R2 in zip(tp[uniq_is],rp2[uniq_is])])
 
         # Apply renormalisation
         seds *= norms[np.searchsorted(uniq_times, self._times)]

--- a/mosfit/modules/transforms/diffusion.py
+++ b/mosfit/modules/transforms/diffusion.py
@@ -1,5 +1,10 @@
 """Definitions for the `Diffusion` class."""
 import numpy as np
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
+
 from scipy.interpolate import interp1d
 
 from mosfit.constants import C_CGS, DAY_CGS, FOUR_PI, KM_CGS, M_SUN_CGS
@@ -67,7 +72,7 @@ class Diffusion(Transform):
             (int_times ** 2 - int_te2s.reshape(lu, 1)) / td2)
         int_args[np.isnan(int_args)] = 0.0
 
-        uniq_lums = np.trapz(int_args, int_times)
+        uniq_lums = trapezoid(int_args, int_times)
         uniq_lums *= -2.0 * np.expm1(-A / int_te2s) / td2
 
         new_lums = uniq_lums[np.searchsorted(uniq_times,

--- a/mosfit/modules/transforms/diffusion_aspherical.py
+++ b/mosfit/modules/transforms/diffusion_aspherical.py
@@ -1,5 +1,10 @@
 """Definitions for the `DiffusionAspherical` class."""
 import numpy as np
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
+
 from scipy.interpolate import interp1d
 
 from mosfit.constants import C_CGS, DAY_CGS, FOUR_PI, KM_CGS, M_SUN_CGS
@@ -75,7 +80,7 @@ class DiffusionAspherical(Transform):
             (int_times ** 2 - int_te2s.reshape(lu, 1)) / td2)
         int_args[np.isnan(int_args)] = 0.0
 
-        uniq_lums = np.trapz(int_args, int_times)
+        uniq_lums = trapezoid(int_args, int_times)
         uniq_lums *= -2.0 * np.expm1(-A / int_te2s) / td2
 
         uniq_lums *= (1 + 1.4 * (2 + uniq_times/self._tau_diff/0.59) / (1 +

--- a/mosfit/modules/transforms/diffusion_csm.py
+++ b/mosfit/modules/transforms/diffusion_csm.py
@@ -2,6 +2,11 @@
 from collections import OrderedDict
 
 import numpy as np
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
+
 from scipy.interpolate import interp1d
 
 from mosfit.constants import C_CGS, DAY_CGS, M_SUN_CGS, AU_CGS
@@ -81,7 +86,7 @@ class DiffusionCSM(Transform):
         int_args = int_lums * np.exp((int_times) / t0)
         int_args[np.isnan(int_args)] = 0.0
 
-        uniq_lums = np.trapz(int_args, int_times)
+        uniq_lums = trapezoid(int_args, int_times)
         uniq_lums*= np.exp(-int_tes/t0)/t0
         new_lums = uniq_lums[np.searchsorted(uniq_times,
                                              self._times_to_process)]

--- a/mosfit/modules/transforms/viscous.py
+++ b/mosfit/modules/transforms/viscous.py
@@ -1,5 +1,10 @@
 """Definitions for the `Viscous` class."""
 import numpy as np
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
+
 from scipy.interpolate import interp1d
 
 from mosfit.modules.transforms.transform import Transform
@@ -50,7 +55,7 @@ class Viscous(Transform):
             (int_times - int_tes.reshape(lu, 1)) / tvisc)
         int_args[np.isnan(int_args)] = 0.0
 
-        uniq_lums = np.trapz(int_args, int_times) / tvisc
+        uniq_lums = trapezoid(int_args, int_times) / tvisc
         new_lums = uniq_lums[np.searchsorted(uniq_times,
                                              self._times_to_process)]
 


### PR DESCRIPTION
I was using MOSFiT for my work with a newer `numpy` version, but was running into an issue because the newer `numpy` version has a breaking API change where they renamed `trapz` to `trapezoid`.
I introduced a change where the code preferably uses the newer numpy `trapezoid` function with a fallback to support older numpy versions.

This edit seems to work on my end, but the installation from source does not (I used the conda package for installation originally and could not install my new local changes easily with pip).

I had trouble running the existing test locally, but my changes should not affect them.

I hope this helps 😄 